### PR TITLE
Make LZOError into a proper Error and use Result for returns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 mod lzo1x_compress;
 mod lzo1x_decompress_safe;
 extern crate libc;
-use std::mem;
-use std::slice;
+use std::error::Error;
+use std::{fmt, mem, slice};
 
 /// for a given `size` computes the worst case size that the compresed result can be
 pub fn worst_compress(size: usize) -> usize {
@@ -13,9 +13,9 @@ const LZO1X_1_MEM_COMPRESS: usize = (8192 * 16);
 const LZO1X_MEM_COMPRESS: usize = LZO1X_1_MEM_COMPRESS;
 
 #[repr(i32)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum LZOError {
-    OK = 0,
+    //OK = 0,
     ERROR = -1,
     OUT_OF_MEMORY = -2,
     NOT_COMPRESSIBLE = -3,
@@ -26,6 +26,26 @@ pub enum LZOError {
     INPUT_NOT_CONSUMED = -8,
     NOT_YET_IMPLEMENTED = -9,
     INVALID_ARGUMENT = -10,
+}
+
+impl fmt::Display for LZOError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LZOError::ERROR => write!(f, "Error"),
+            LZOError::OUT_OF_MEMORY => write!(f, "Out of memory"),
+            LZOError::NOT_COMPRESSIBLE => write!(f, "Not compressible"),
+            LZOError::INPUT_OVERRUN => write!(f, "Input overrun"),
+            LZOError::OUTPUT_OVERRUN => write!(f, "Output overrun"),
+            LZOError::LOOKBEHIND_OVERRUN => write!(f, "Lookbehind overrun"),
+            LZOError::EOF_NOT_FOUND => write!(f, "EOF not found"),
+            LZOError::INPUT_NOT_CONSUMED => write!(f, "Input not consumed"),
+            LZOError::NOT_YET_IMPLEMENTED => write!(f, "Not yet implemented"),
+            LZOError::INVALID_ARGUMENT => write!(f, "Invalid argument"),
+        }
+    }
+}
+
+impl Error for LZOError {
 }
 
 pub struct LZOContext {
@@ -47,7 +67,7 @@ impl LZOContext {
 
     /// compress `input` into `output`
     /// returns an error if the Vec is not large enough
-    pub fn compress(&mut self, input: &[u8], output: &mut Vec<u8>) -> LZOError {
+    pub fn compress(&mut self, input: &[u8], output: &mut Vec<u8>) -> Result<(), LZOError> {
         unsafe {
             let mut out_len = output.capacity();
             let err = lzo1x_compress::lzo1x_1_compress(input.as_ptr(),
@@ -57,12 +77,16 @@ impl LZOContext {
                                                        &mut *self.wrkmem as *mut _ as *mut _);
 
             output.set_len(out_len);
-            mem::transmute::<i32, LZOError>(err)
+            if err == 0 {
+                Ok(())
+            }else {
+                Err(mem::transmute::<i32, LZOError>(err))
+            }
         }
     }
 
     /// returns a slice containing the compressed data
-    pub fn compress_to_slice<'a>(&mut self, in_: &[u8], out: &'a mut [u8]) -> (&'a mut [u8], LZOError) {
+    pub fn compress_to_slice<'a>(&mut self, in_: &[u8], out: &'a mut [u8]) -> Result<&'a mut [u8], LZOError> {
         unsafe {
             let mut out_len = out.len();
             let err = lzo1x_compress::lzo1x_1_compress(in_.as_ptr(),
@@ -70,21 +94,27 @@ impl LZOContext {
                                                        out.as_mut_ptr(),
                                                        &mut out_len,
                                                        &mut *self.wrkmem as *mut _ as *mut _);
-            (slice::from_raw_parts_mut(out.as_mut_ptr(), out_len),
-             mem::transmute::<i32, LZOError>(err))
+            if err == 0 {
+                Ok(slice::from_raw_parts_mut(out.as_mut_ptr(), out_len))
+            }else {
+                Err(mem::transmute::<i32, LZOError>(err))
+            }
         }
     }
 
     /// returns a slice containing the decompressed data
-    pub fn decompress_to_slice<'a>(in_: &[u8], out: &'a mut [u8]) -> (&'a mut [u8], LZOError) {
+    pub fn decompress_to_slice<'a>(in_: &[u8], out: &'a mut [u8]) -> Result<&'a mut [u8], LZOError> {
         unsafe {
             let mut out_len = out.len();
             let err = lzo1x_decompress_safe::lzo1x_decompress_safe(in_.as_ptr(),
                                                                    in_.len(),
                                                                    out.as_mut_ptr(),
                                                                    &mut out_len);
-            (slice::from_raw_parts_mut(out.as_mut_ptr(), out_len),
-             mem::transmute::<i32, LZOError>(err))
+            if err == 0 {
+                Ok(slice::from_raw_parts_mut(out.as_mut_ptr(), out_len))
+            }else {
+                Err(mem::transmute::<i32, LZOError>(err))
+            }
         }
     }
 }
@@ -101,19 +131,21 @@ fn it_works() {
         let dst = libc::malloc(dst_len);
         let mut ctx = LZOContext::new();
         let mut dst = slice::from_raw_parts_mut(dst as *mut u8, dst_len);
-        let (dst, err) = ctx.compress_to_slice(&data, &mut dst);
-        assert!(err == LZOError::OK);
-        let err = ctx.compress(&data, &mut v);
-        assert!(err == LZOError::OK);
+        let result = ctx.compress_to_slice(&data, &mut dst);
+        assert_eq!(result.is_ok(), true);
+        let dst = result.unwrap();
+        let result = ctx.compress(&data, &mut v);
+        assert_eq!(result.is_ok(), true);
         println!("{}", dst.len());
 
         let dec_dst = libc::malloc(mem::size_of_val(&data));
         let result_len = mem::size_of_val(&data);
         let mut dec_dst = slice::from_raw_parts_mut(dec_dst as *mut u8, result_len);
-        let (result, err) = LZOContext::decompress_to_slice(&dst, &mut dec_dst);
-        assert!(err == LZOError::OK);
+        let result = LZOContext::decompress_to_slice(&dst, &mut dec_dst);
+        assert_eq!(result.is_ok(), true);
+        let result = result.unwrap();
         println!("{}", result.len());
-        assert!(result.len() == mem::size_of_val(&data));
+        assert_eq!(result.len(), mem::size_of_val(&data));
         assert!(&data[..] == result);
     }
 


### PR DESCRIPTION
This makes handling errors much easier for crate users.